### PR TITLE
Make program exit properly on secondary forms

### DIFF
--- a/FF12RNGHelper.csproj
+++ b/FF12RNGHelper.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="src\Forms\FormUtils.cs" />
     <Compile Include="src\RNGHelper\Internal\BaseRngHelper.cs" />
     <Compile Include="src\RNGHelper\Character.cs" />
     <Compile Include="src\RNGHelper\CharacterGroup.cs" />

--- a/src/Forms/FormChest2.Designer.cs
+++ b/src/Forms/FormChest2.Designer.cs
@@ -1093,6 +1093,7 @@ namespace FF12RNGHelper
             this.Name = "FormChest2";
             this.Text = "FF12 RNG Helper";
             this.Load += new System.EventHandler(this.FormChest_Load);
+            this.FormClosed += FormUtils.CloseApplication;
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.gbStats.ResumeLayout(false);

--- a/src/Forms/FormSpawn.Designer.cs
+++ b/src/Forms/FormSpawn.Designer.cs
@@ -948,6 +948,7 @@
             this.Name = "FormSpawn";
             this.Text = "FF12 RNG Helper";
             this.Load += new System.EventHandler(this.FormChest_Load);
+            this.FormClosed += FormUtils.CloseApplication;
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.gbStats.ResumeLayout(false);

--- a/src/Forms/FormSteal.Designer.cs
+++ b/src/Forms/FormSteal.Designer.cs
@@ -772,7 +772,8 @@
             this.MinimumSize = new System.Drawing.Size(557, 601);
             this.Name = "FormSteal";
             this.Text = "FF12 RNG Helper";
-            this.Load += new System.EventHandler(this.FormChest_Load);
+		    this.Load += new System.EventHandler(this.FormChest_Load);
+            this.FormClosed += FormUtils.CloseApplication;
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.gbStats.ResumeLayout(false);

--- a/src/Forms/FormUtils.cs
+++ b/src/Forms/FormUtils.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace FF12RNGHelper
+{
+    public static class FormUtils
+    {
+        public static void CloseApplication(object o, FormClosedEventArgs e)
+        {
+            Application.Exit();
+        }
+    }
+}


### PR DESCRIPTION
Turns out only the main form automatically calls Application.Exit() when closed. Added a FormClosed event handler to call Application.Close().

No more zombie processes. :)

Fixes Issue #25 